### PR TITLE
Cria formatador/desformatador de CPF

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,3 +2,26 @@
 
 * classe E5R.Architecture.Core.**SemVer** básica
 * classe E5R.Architecture.Data.**Data** temporária
+* Formatador de string CPF
+```csharp
+using E5R.Architecture.Core.Formatters;
+
+// code block
+{
+   string cpfFormatado = (FormattedCPF)"12345678901"; 
+}
+
+// output $cpfFormatado => "123.456.789-01"
+```
+
+* Desformatador de string de CPF
+```csharp
+using E5R.Architecture.Core.Formatters;
+
+// code block
+{
+   string cpfDesformatado = (UnformattedCPF)"123.456.789-01"; 
+}
+
+// output $cpfDesformatado => "12345678901"
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # E5R.Architecture
-Componentes da arquitetura de software E5R Development Team para .NET Standard >= 1.1, .NET >= 4.0.
+Componentes da arquitetura de software E5R Development Team para .NET Standard >= 1.0, .NET >= 4.0.
 
 
 ## Construção

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # E5R.Architecture
-Componentes da arquitetura de software E5R Development Team para .NET Standard 1.6, .NET 4.0, 4.5 e 4.6.
+Componentes da arquitetura de software E5R Development Team para .NET Standard >= 1.1, .NET >= 4.0.
 
 
 ## Construção

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # E5R.Architecture
-Componentes da arquitetura de software E5R Development Team para .NET Standard 1.0, .NET 4.0, 4.5 e 4.6.
+Componentes da arquitetura de software E5R Development Team para .NET Standard 1.6, .NET 4.0, 4.5 e 4.6.
 
 
 ## Construção

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ artifacts:
     name: E5RArchitecturePackages
 
 cache:
+  - '%ProgramData%\chocolatey\bin -> appveyor.yml'
   - '%ProgramData%\chocolatey\lib -> appveyor.yml'
 
 init:
@@ -27,8 +28,14 @@ install:
       $ENV:BUILD_VERSION_SUFFIX = "${BUILD_LABEL}-${BUILD_NUMBER}";
       $BUILD_VERSION = (Select-Xml -Path ".\packages.props" -XPath "/Project/PropertyGroup/VersionPrefix" | Select-Object -ExpandProperty Node).InnerText;
       Update-AppveyorBuild -Version "${BUILD_VERSION}-${ENV:BUILD_VERSION_SUFFIX}";
-      cinst opencover.portable --force;
-      cinst codecov --force;
+      if(!(test-path ${env:ProgramData}\chocolatey\bin\opencover.console.exe))
+      {
+        cinst opencover.portable;
+      }
+      if(!(test-path ${env:ProgramData}\chocolatey\bin\codecov.exe))
+      {
+        cinst codecov;
+      }
 
 before_build:
   - ps: 'dotnet --info'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,9 +46,11 @@ build_script:
 
 test_script :
   - ps: 'opencover.console -register:user -target:"dotnet.exe" -targetargs:"test .\test\E5R.Architecture.Core.Test" -output:".\E5R.Architecture.Core.Test.Coverage.xml" -oldstyle'
+  - ps: 'opencover.console -register:user -target:"dotnet.exe" -targetargs:"test .\test\E5R.Architecture.Data.Test" -output:".\E5R.Architecture.Data.Test.Coverage.xml" -oldstyle'
 
 after_test:
   - ps: 'codecov -f .\E5R.Architecture.Core.Test.Coverage.xml'
+  - ps: 'codecov -f .\E5R.Architecture.Data.Test.Coverage.xml'
 
 deploy:
   - provider: NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,10 @@
 
 image: Visual Studio 2017
 configuration: Release
-platform: Any CPU
+platform:
+- x86
+- x64
+
 clone_depth: 1
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,7 @@
 
 image: Visual Studio 2017
 configuration: Release
-platform:
-- x86
-- x64
+platform: Any CPU
 
 clone_depth: 1
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,6 @@
 # Licensed under the Apache License, Version 2.0. More license information in LICENSE.txt.
 
 codecov:
-  branch: master
+  branch:
+  - master
+  - develop

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json.schemastore.org/global",
     "sdk": {
-        "version": "2.0.0"
+        "version": "2.1.4"
     }
 }

--- a/packages.props
+++ b/packages.props
@@ -14,12 +14,12 @@
     <PackageProjectUrl>https://github.com/e5r/E5R.Architecture</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/e5r/E5R.Architecture/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/8513737</PackageIconUrl>
-    <PackageReleaseNotes>Componentes da arquitetura de software E5R Development Team para .NET Standard >= 1.1 e .NET >= 4.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Componentes da arquitetura de software E5R Development Team para .NET Standard >= 1.0 e .NET >= 4.0</PackageReleaseNotes>
     <PackageTags>E5R Development Team Architecture</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <TargetFrameworks>netcoreapp1.1;netstandard2.0;netstandard1.1;netstandard2.0;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netstandard2.0;netstandard1.0;netstandard2.0;net46;net45</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <OutputPath>$(SolutionDir)artifacts</OutputPath>
   </PropertyGroup>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>Full</DebugType>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <TargetFrameworks>netcoreapp1.1;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netstandard1.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/packages.props
+++ b/packages.props
@@ -1,7 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.6;netstandard1.0;net46;net45</TargetFrameworks>
     <VersionPrefix>0.1.0</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
@@ -20,6 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <TargetFrameworks>netcoreapp1.0;netstandard2.0;netstandard1.6;netstandard1.0;net46;net45</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <OutputPath>$(SolutionDir)artifacts</OutputPath>
   </PropertyGroup>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>Full</DebugType>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netstandard1.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/packages.props
+++ b/packages.props
@@ -4,7 +4,7 @@
     <VersionPrefix>0.1.0</VersionPrefix>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-    <RootNamespace>E5R.Architecture</RootNamespace>
+    <RootPkgNamespace>E5R.Architecture</RootPkgNamespace>
     <Product>E5R.Architecture</Product>
     <Company>E5R Development Team</Company>
     <Authors>erlimar</Authors>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <TargetFrameworks>netcoreapp1.0;netstandard2.0;netstandard1.6;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netstandard2.0;netstandard1.0;netstandard2.0;net46;net45</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <OutputPath>$(SolutionDir)artifacts</OutputPath>
   </PropertyGroup>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>Full</DebugType>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <TargetFrameworks>netcoreapp1.0;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netstandard1.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/packages.props
+++ b/packages.props
@@ -14,12 +14,12 @@
     <PackageProjectUrl>https://github.com/e5r/E5R.Architecture</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/e5r/E5R.Architecture/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/8513737</PackageIconUrl>
-    <PackageReleaseNotes>Componentes da arquitetura de software E5R Development Team para .NET Standard 1.0, .NET 4.0, 4.5 e 4.6.</PackageReleaseNotes>
+    <PackageReleaseNotes>Componentes da arquitetura de software E5R Development Team para .NET Standard 1.6, .NET 4.0, 4.5 e 4.6.</PackageReleaseNotes>
     <PackageTags>E5R Development Team Architecture</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <TargetFrameworks>netcoreapp1.0;netstandard2.0;netstandard1.6;netstandard1.0;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netstandard2.0;netstandard1.6;net46;net45</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <OutputPath>$(SolutionDir)artifacts</OutputPath>
   </PropertyGroup>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>Full</DebugType>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <TargetFrameworks>netcoreapp1.0;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netstandard1.6</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/packages.props
+++ b/packages.props
@@ -14,12 +14,12 @@
     <PackageProjectUrl>https://github.com/e5r/E5R.Architecture</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/e5r/E5R.Architecture/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/8513737</PackageIconUrl>
-    <PackageReleaseNotes>Componentes da arquitetura de software E5R Development Team para .NET Standard 1.6, .NET 4.0, 4.5 e 4.6.</PackageReleaseNotes>
+    <PackageReleaseNotes>Componentes da arquitetura de software E5R Development Team para .NET Standard >= 1.1 e .NET >= 4.0</PackageReleaseNotes>
     <PackageTags>E5R Development Team Architecture</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <TargetFrameworks>netcoreapp1.0;netstandard2.0;netstandard1.0;netstandard2.0;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netstandard2.0;netstandard1.1;netstandard2.0;net46;net45</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <OutputPath>$(SolutionDir)artifacts</OutputPath>
   </PropertyGroup>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>Full</DebugType>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <TargetFrameworks>netcoreapp1.0;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netstandard1.1</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/E5R.Architecture.Core/E5R.Architecture.Core.csproj
+++ b/src/E5R.Architecture.Core/E5R.Architecture.Core.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <AssemblyName>E5R.Architecture.Core</AssemblyName>
     <PackageId>E5R.Architecture.Core</PackageId>
+    <RootNamespace>$(RootPkgNamespace).Core</RootNamespace>
     <Description>Componente principal, base para todos os outros da arquitetura de software E5R Development Team</Description>
   </PropertyGroup>
 

--- a/src/E5R.Architecture.Core/Formatters/FormattedCPF.cs
+++ b/src/E5R.Architecture.Core/Formatters/FormattedCPF.cs
@@ -2,15 +2,15 @@ using System;
 
 namespace E5R.Architecture.Core.Formatters
 {
-    public class FormattedCPF
+    public class FormattedCpf
     {
         private long _value;
 
         /// <summary>
         /// Format Brazilian CPF string
         /// </summary>
-        /// <param name="formatted"></param>
-        public FormattedCPF(string value)
+        /// <param name="value">Value of unformatted CPF</param>
+        private FormattedCpf(string value)
         {
             value = value
                 ?? throw new ArgumentNullException(nameof(value));
@@ -26,28 +26,22 @@ namespace E5R.Architecture.Core.Formatters
             }
         }
 
-        private string Value
-        {
-            get
-            {
-                return _value.ToString(@"000\.000\.000\-00");
-            }
-        }
+        private string Value => _value.ToString(@"000\.000\.000\-00");
 
         /// <summary>
-        /// Conversion from <see cref="string" /> to <see cref="FormattedCPF" />
+        /// Conversion from <see cref="string" /> to <see cref="FormattedCpf" />
         /// </summary>
         /// <param name="unformatted">Unformatted CPF string</param>
-        public static explicit operator FormattedCPF(string unformatted)
+        public static explicit operator FormattedCpf(string unformatted)
         {
-            return new FormattedCPF(unformatted);
+            return new FormattedCpf(unformatted);
         }
 
         /// <summary>
-        /// Conversion from <see cref="FormattedCPF" /> to <see cref="string" />
+        /// Conversion from <see cref="FormattedCpf" /> to <see cref="string" />
         /// </summary>
         /// <param name="formatter">CPF formatter</param>
-        public static implicit operator string(FormattedCPF formatter)
+        public static implicit operator string(FormattedCpf formatter)
         {
             return formatter.Value;
         }

--- a/src/E5R.Architecture.Core/Formatters/FormattedCPF.cs
+++ b/src/E5R.Architecture.Core/Formatters/FormattedCPF.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace E5R.Architecture.Core.Formatters
+{
+    public class FormattedCPF
+    {
+        private long _value;
+
+        /// <summary>
+        /// Format Brazilian CPF string
+        /// </summary>
+        /// <param name="formatted"></param>
+        public FormattedCPF(string value)
+        {
+            value = value
+                ?? throw new ArgumentNullException(nameof(value));
+
+            EnsureLongValue(value);
+        }
+
+        private void EnsureLongValue(string value)
+        {
+            if(string.IsNullOrEmpty(value) || value.Length > 11 || !long.TryParse(value, out _value))
+            {
+                throw new FormatException("Invalid unformatted CPF string value");
+            }
+        }
+
+        private string Value
+        {
+            get
+            {
+                return _value.ToString(@"000\.000\.000\-00");
+            }
+        }
+
+        /// <summary>
+        /// Conversion from <see cref="string" /> to <see cref="FormattedCPF" />
+        /// </summary>
+        /// <param name="unformatted">Unformatted CPF string</param>
+        public static explicit operator FormattedCPF(string unformatted)
+        {
+            return new FormattedCPF(unformatted);
+        }
+
+        /// <summary>
+        /// Conversion from <see cref="FormattedCPF" /> to <see cref="string" />
+        /// </summary>
+        /// <param name="formatter">CPF formatter</param>
+        public static implicit operator string(FormattedCPF formatter)
+        {
+            return formatter.Value;
+        }
+    }
+}

--- a/src/E5R.Architecture.Core/Formatters/UnformattedCPF.cs
+++ b/src/E5R.Architecture.Core/Formatters/UnformattedCPF.cs
@@ -3,15 +3,15 @@ using System.Linq;
 
 namespace E5R.Architecture.Core.Formatters
 {
-    public class UnformattedCPF
+    public class UnformattedCpf
     {
         private string _value;
 
         /// <summary>
         /// Unformat Brazilian CPF string
         /// </summary>
-        /// <param name="formatted"></param>
-        public UnformattedCPF(string value)
+        /// <param name="value">Value of formatted CPF</param>
+        private UnformattedCpf(string value)
         {
             value = value
                 ?? throw new ArgumentNullException(nameof(value));
@@ -25,26 +25,26 @@ namespace E5R.Architecture.Core.Formatters
                 ?.Replace(".", string.Empty)
                 ?.Replace("-", string.Empty);
 
-            if(string.IsNullOrEmpty(_value) || _value.Length > 11 || _value.Any(c => !char.IsNumber(c)))
+            if(string.IsNullOrEmpty(_value) || _value.Length > 11 || _value.ToCharArray().Any(c => !char.IsNumber(c)))
             {
                 throw new FormatException("Invalid formatted CPF string value");
             }
         }
 
         /// <summary>
-        /// Conversion from <see cref="string" /> to <see cref="UnformattedCPF" />
+        /// Conversion from <see cref="string" /> to <see cref="UnformattedCpf" />
         /// </summary>
         /// <param name="formatted">Formatted CPF string</param>
-        public static explicit operator UnformattedCPF(string formatted)
+        public static explicit operator UnformattedCpf(string formatted)
         {
-            return new UnformattedCPF(formatted);
+            return new UnformattedCpf(formatted);
         }
 
         /// <summary>
-        /// Conversion from <see cref="UnformattedCPF" /> to <see cref="string" />
+        /// Conversion from <see cref="UnformattedCpf" /> to <see cref="string" />
         /// </summary>
         /// <param name="unformatter">CPF unformatter</param>
-        public static implicit operator string(UnformattedCPF unformatter)
+        public static implicit operator string(UnformattedCpf unformatter)
         {
             return unformatter._value;
         }

--- a/src/E5R.Architecture.Core/Formatters/UnformattedCPF.cs
+++ b/src/E5R.Architecture.Core/Formatters/UnformattedCPF.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+
+namespace E5R.Architecture.Core.Formatters
+{
+    public class UnformattedCPF
+    {
+        private string _value;
+
+        /// <summary>
+        /// Unformat Brazilian CPF string
+        /// </summary>
+        /// <param name="formatted"></param>
+        public UnformattedCPF(string value)
+        {
+            value = value
+                ?? throw new ArgumentNullException(nameof(value));
+
+            EnsureValue(value);
+        }
+
+        private void EnsureValue(string value)
+        {
+            _value = value
+                ?.Replace(".", string.Empty)
+                ?.Replace("-", string.Empty);
+
+            if(string.IsNullOrEmpty(_value) || _value.Length > 11 || _value.Any(c => !char.IsNumber(c)))
+            {
+                throw new FormatException("Invalid formatted CPF string value");
+            }
+        }
+
+        /// <summary>
+        /// Conversion from <see cref="string" /> to <see cref="UnformattedCPF" />
+        /// </summary>
+        /// <param name="formatted">Formatted CPF string</param>
+        public static explicit operator UnformattedCPF(string formatted)
+        {
+            return new UnformattedCPF(formatted);
+        }
+
+        /// <summary>
+        /// Conversion from <see cref="UnformattedCPF" /> to <see cref="string" />
+        /// </summary>
+        /// <param name="unformatter">CPF unformatter</param>
+        public static implicit operator string(UnformattedCPF unformatter)
+        {
+            return unformatter._value;
+        }
+    }
+}

--- a/src/E5R.Architecture.Data/E5R.Architecture.Data.csproj
+++ b/src/E5R.Architecture.Data/E5R.Architecture.Data.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <AssemblyName>E5R.Architecture.Data</AssemblyName>
     <PackageId>E5R.Architecture.Data</PackageId>
+    <RootNamespace>$(RootPkgNamespace).Data</RootNamespace>
     <Description>Componente de dados, parte da arquitetura de software E5R Development Team</Description>
   </PropertyGroup>
 

--- a/test/E5R.Architecture.Core.Test/E5R.Architecture.Core.Test.csproj
+++ b/test/E5R.Architecture.Core.Test/E5R.Architecture.Core.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/E5R.Architecture.Core.Test/E5R.Architecture.Core.Test.csproj
+++ b/test/E5R.Architecture.Core.Test/E5R.Architecture.Core.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0;netstandard1.6</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netstandard1.6</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/E5R.Architecture.Core.Test/E5R.Architecture.Core.Test.csproj
+++ b/test/E5R.Architecture.Core.Test/E5R.Architecture.Core.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0;netstandard1.6</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/E5R.Architecture.Core.Test/E5R.Architecture.Core.Test.csproj
+++ b/test/E5R.Architecture.Core.Test/E5R.Architecture.Core.Test.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netstandard1.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/E5R.Architecture.Core.Test/Formatters/FormattedCPFTests.cs
+++ b/test/E5R.Architecture.Core.Test/Formatters/FormattedCPFTests.cs
@@ -1,21 +1,20 @@
 using System;
+using E5R.Architecture.Core.Formatters;
 using Xunit;
 
-namespace E5R.Architecture.Core.Tests.Formatters
+namespace E5R.Architecture.Core.Test.Formatters
 {
-    using Core.Formatters;
-
-    public class FormattedCPFTests
+    public class FormattedCpfTests
     {
         [Fact]
         public void Must_Format_An_Literal_Unformatted_CPF_String()
         {
-            string exptected = "123.456.789-01";
-            string calculated = (FormattedCPF)"12345678901";
+            const string expected = "123.456.789-01";
+            string calculated = (FormattedCpf)"12345678901";
 
-            Assert.Equal(exptected, calculated);
-            Assert.Equal(exptected, (FormattedCPF)"12345678901");
-            Assert.Equal(exptected, (string)(FormattedCPF)"12345678901");
+            Assert.Equal(expected, calculated);
+            Assert.Equal(expected, (FormattedCpf)"12345678901");
+            Assert.Equal(expected, (string)(FormattedCpf)"12345678901");
         }
 
         [Theory]
@@ -34,11 +33,11 @@ namespace E5R.Architecture.Core.Tests.Formatters
         [InlineData("00000000000", "000.000.000-00")]
         public void Must_Format_An_Unformatted_CPF_String(string unformatted, string formatted)
         {
-            string calculated = (FormattedCPF)unformatted;
+            string calculated = (FormattedCpf)unformatted;
 
             Assert.Equal(formatted, calculated);
-            Assert.Equal(formatted, (FormattedCPF)unformatted);
-            Assert.Equal(formatted, (string)(FormattedCPF)unformatted);
+            Assert.Equal(formatted, (FormattedCpf)unformatted);
+            Assert.Equal(formatted, (string)(FormattedCpf)unformatted);
         }
 
         [Theory]
@@ -47,7 +46,7 @@ namespace E5R.Architecture.Core.Tests.Formatters
         [InlineData("01235678900#")]
         public void Only_Number_Is_Accepted_On_String(string value)
         {
-            Assert.Throws<FormatException>(() => { string calculated = (FormattedCPF)value; });
+            Assert.Throws<FormatException>(() => { string calculated = (FormattedCpf)value; });
         }
 
         [Theory]
@@ -55,7 +54,7 @@ namespace E5R.Architecture.Core.Tests.Formatters
         public void Max_11Chars(string value)
         {
             Assert.Throws<FormatException>(() => {
-                string calculated = (FormattedCPF)value;
+                string calculated = (FormattedCpf)value;
             });
         }
     }

--- a/test/E5R.Architecture.Core.Test/Formatters/FormattedCPFTests.cs
+++ b/test/E5R.Architecture.Core.Test/Formatters/FormattedCPFTests.cs
@@ -7,6 +7,17 @@ namespace E5R.Architecture.Core.Tests.Formatters
 
     public class FormattedCPFTests
     {
+        [Fact]
+        public void Must_Format_An_Literal_Unformatted_CPF_String()
+        {
+            string exptected = "123.456.789-01";
+            string calculated = (FormattedCPF)"12345678901";
+
+            Assert.Equal(exptected, calculated);
+            Assert.Equal(exptected, (FormattedCPF)"12345678901");
+            Assert.Equal(exptected, (string)(FormattedCPF)"12345678901");
+        }
+
         [Theory]
         [InlineData("1", "000.000.000-01")]
         [InlineData("12", "000.000.000-12")]

--- a/test/E5R.Architecture.Core.Test/Formatters/FormattedCPFTests.cs
+++ b/test/E5R.Architecture.Core.Test/Formatters/FormattedCPFTests.cs
@@ -1,0 +1,51 @@
+using System;
+using Xunit;
+
+namespace E5R.Architecture.Core.Tests.Formatters
+{
+    using Core.Formatters;
+
+    public class FormattedCPFTests
+    {
+        [Theory]
+        [InlineData("1", "000.000.000-01")]
+        [InlineData("12", "000.000.000-12")]
+        [InlineData("123", "000.000.001-23")]
+        [InlineData("1234", "000.000.012-34")]
+        [InlineData("12345", "000.000.123-45")]
+        [InlineData("123456", "000.001.234-56")]
+        [InlineData("1234567", "000.012.345-67")]
+        [InlineData("12345678", "000.123.456-78")]
+        [InlineData("123456789", "001.234.567-89")]
+        [InlineData("1234567890", "012.345.678-90")]
+        [InlineData("01235678901", "012.356.789-01")]
+        [InlineData("99999999999", "999.999.999-99")]
+        [InlineData("00000000000", "000.000.000-00")]
+        public void Must_Format_An_Unformatted_CPF_String(string unformatted, string formatted)
+        {
+            string calculated = (FormattedCPF)unformatted;
+
+            Assert.Equal(formatted, calculated);
+            Assert.Equal(formatted, (FormattedCPF)unformatted);
+            Assert.Equal(formatted, (string)(FormattedCPF)unformatted);
+        }
+
+        [Theory]
+        [InlineData("c")]
+        [InlineData("!")]
+        [InlineData("01235678900#")]
+        public void Only_Number_Is_Accepted_On_String(string value)
+        {
+            Assert.Throws<FormatException>(() => { string calculated = (FormattedCPF)value; });
+        }
+
+        [Theory]
+        [InlineData("000000000000")]
+        public void Max_11Chars(string value)
+        {
+            Assert.Throws<FormatException>(() => {
+                string calculated = (FormattedCPF)value;
+            });
+        }
+    }
+}

--- a/test/E5R.Architecture.Core.Test/Formatters/UnformattedCPFTests.cs
+++ b/test/E5R.Architecture.Core.Test/Formatters/UnformattedCPFTests.cs
@@ -7,6 +7,17 @@ namespace E5R.Architecture.Core.Tests.Formatters
 
     public class UnformattedCPFTests
     {
+        [Fact]
+        public void Must_Unformat_An_Literal_Formatted_CPF_String()
+        {
+            string exptected = "12345678901";
+            string calculated = (UnformattedCPF)"123.456.789-01";
+
+            Assert.Equal(exptected, calculated);
+            Assert.Equal(exptected, (UnformattedCPF)"123.456.789-01");
+            Assert.Equal(exptected, (string)(UnformattedCPF)"123.456.789-01");
+        }
+
         [Theory]
         [InlineData("1", "1")]
         [InlineData("12", "-12")]

--- a/test/E5R.Architecture.Core.Test/Formatters/UnformattedCPFTests.cs
+++ b/test/E5R.Architecture.Core.Test/Formatters/UnformattedCPFTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Xunit;
+
+namespace E5R.Architecture.Core.Tests.Formatters
+{
+    using Core.Formatters;
+
+    public class UnformattedCPFTests
+    {
+        [Theory]
+        [InlineData("1", "1")]
+        [InlineData("12", "-12")]
+        [InlineData("123", "1-23")]
+        [InlineData("1234", "12-34")]
+        [InlineData("12345", ".123-45")]
+        [InlineData("123456", "1.234-56")]
+        [InlineData("1234567", "12.345-67")]
+        [InlineData("12345678", ".123.456-78")]
+        [InlineData("123456789", "1.234.567-89")]
+        [InlineData("1234567890", "12.345.678-90")]
+        [InlineData("01235678901", "012.356.789-01")]
+        [InlineData("99999999999", "999.999.999-99")]
+        [InlineData("00000000000", "000.000.000-00")]
+        public void Must_Unformat_An_Formatted_CPF_String(string unformatted, string formatted)
+        {
+            string calculated = (UnformattedCPF)formatted;
+
+            Assert.Equal(unformatted, calculated);
+            Assert.Equal(unformatted, (UnformattedCPF)formatted);
+            Assert.Equal(unformatted, (string)(UnformattedCPF)formatted);
+        }
+
+        [Theory]
+        [InlineData("c")]
+        [InlineData("!")]
+        [InlineData("01235678900#")]
+        [InlineData("012.35678900#")]
+        [InlineData("012-5678900#")]
+        public void Only_Number_Dot_And_Dash_Is_Accepted_On_String(string value)
+        {
+            Assert.Throws<FormatException>(() => { string calculated = (UnformattedCPF)value; });
+        }
+
+        [Theory]
+        [InlineData("000.000.000-000")]
+        public void Max_11Numeric_Chars(string value)
+        {
+            Assert.Throws<FormatException>(() => {
+                string calculated = (UnformattedCPF)value;
+            });
+        }
+    }
+}

--- a/test/E5R.Architecture.Core.Test/Formatters/UnformattedCpfTests.cs
+++ b/test/E5R.Architecture.Core.Test/Formatters/UnformattedCpfTests.cs
@@ -1,21 +1,20 @@
 using System;
+using  E5R.Architecture.Core.Formatters;
 using Xunit;
 
-namespace E5R.Architecture.Core.Tests.Formatters
+namespace E5R.Architecture.Core.Test.Formatters
 {
-    using Core.Formatters;
-
-    public class UnformattedCPFTests
+    public class UnformattedCpfTests
     {
         [Fact]
         public void Must_Unformat_An_Literal_Formatted_CPF_String()
         {
-            string exptected = "12345678901";
-            string calculated = (UnformattedCPF)"123.456.789-01";
+            const string expected = "12345678901";
+            string calculated = (UnformattedCpf)"123.456.789-01";
 
-            Assert.Equal(exptected, calculated);
-            Assert.Equal(exptected, (UnformattedCPF)"123.456.789-01");
-            Assert.Equal(exptected, (string)(UnformattedCPF)"123.456.789-01");
+            Assert.Equal(expected, calculated);
+            Assert.Equal(expected, (UnformattedCpf)"123.456.789-01");
+            Assert.Equal(expected, (string)(UnformattedCpf)"123.456.789-01");
         }
 
         [Theory]
@@ -34,11 +33,11 @@ namespace E5R.Architecture.Core.Tests.Formatters
         [InlineData("00000000000", "000.000.000-00")]
         public void Must_Unformat_An_Formatted_CPF_String(string unformatted, string formatted)
         {
-            string calculated = (UnformattedCPF)formatted;
+            string calculated = (UnformattedCpf)formatted;
 
             Assert.Equal(unformatted, calculated);
-            Assert.Equal(unformatted, (UnformattedCPF)formatted);
-            Assert.Equal(unformatted, (string)(UnformattedCPF)formatted);
+            Assert.Equal(unformatted, (UnformattedCpf)formatted);
+            Assert.Equal(unformatted, (string)(UnformattedCpf)formatted);
         }
 
         [Theory]
@@ -49,7 +48,7 @@ namespace E5R.Architecture.Core.Tests.Formatters
         [InlineData("012-5678900#")]
         public void Only_Number_Dot_And_Dash_Is_Accepted_On_String(string value)
         {
-            Assert.Throws<FormatException>(() => { string calculated = (UnformattedCPF)value; });
+            Assert.Throws<FormatException>(() => { string calculated = (UnformattedCpf)value; });
         }
 
         [Theory]
@@ -57,7 +56,7 @@ namespace E5R.Architecture.Core.Tests.Formatters
         public void Max_11Numeric_Chars(string value)
         {
             Assert.Throws<FormatException>(() => {
-                string calculated = (UnformattedCPF)value;
+                string calculated = (UnformattedCpf)value;
             });
         }
     }

--- a/test/E5R.Architecture.Data.Test/E5R.Architecture.Data.Test.csproj
+++ b/test/E5R.Architecture.Data.Test/E5R.Architecture.Data.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/E5R.Architecture.Data.Test/E5R.Architecture.Data.Test.csproj
+++ b/test/E5R.Architecture.Data.Test/E5R.Architecture.Data.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0;netstandard1.6</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netstandard1.6</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/E5R.Architecture.Data.Test/E5R.Architecture.Data.Test.csproj
+++ b/test/E5R.Architecture.Data.Test/E5R.Architecture.Data.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0;netstandard1.6</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/E5R.Architecture.Data.Test/E5R.Architecture.Data.Test.csproj
+++ b/test/E5R.Architecture.Data.Test/E5R.Architecture.Data.Test.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netstandard1.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />


### PR DESCRIPTION
O formatador/desformatador de CPF é somente uma exemplificação da ideia que queremos apresentar para se trabalhar com formatação/desformatação de strings.

O que queremos é ao invés de usar a sintaxe já bem conhecida:

```csharp
string cpfFormatado = "12345678901".FormataCPF();
```

Pra essa sintaxe:

```csharp
string cpfFormatado = (CPFFormatado)"12345678901";
```

Aonde deixamos claro e de forma explícita uma conversão de "tipos", na verdade um mesmo tipo, porém de uma representação `12345678901` para outra (no caso `123.456.789-01`).

Lendo o primeiro código estamos dizendo **Executa uma ação `FormataCPF`**.
Enquanto na segunda estamos dizendo ***Converta essa string para um valor chamado `CPFFormatado`***

A segunda forma de dizer me parece mais coerente, porque estamos realmente fazendo uma conversão.

Podemos deixar o exemplo do CPF um pouco mais completo, se simplesmente generalizarmos a questão de formatado/desformatado. Podemos assumir que uma string de CPF sempre deve ser formatada, e quando preferirmos podemos desformatá-la (para guardar no banco de dados por exemplo). Ou se ao guardarmos no banco vamos fazer isso com um **INTEGER** ao invés de um **VARCHAR** então seria últil transformar o CPF em uma representação de **int** antes disso.

Tudo isso poderia ser simplificado assim:

```csharp
// Sempre será "001.234.567-89"
string cpf1 = (CPF)"00123456789"; 

// converte para inteiro [123456789]
int cpf2 = (CPF)"001.234.567-89";

// forçamos "00123456789"
string cpf3 = (CPFDesformatado)"001.234.567-89";

// o que também se encarrega de garantir os "zeros à esquerda"
// isso já seria uma regra mais elaborada: "00001234567"
string cpf4 = (CPFDesformatado)"1234567";
```

Se temos essa versatilidade com esse modelo, e em se falando de conversão, podemos aproveitar a deixa e usar o mesmo princípio para outras conversões que já conhecemos:

```csharp
int inteiro = (Numero)"7899";
double decimal = (Numero)"897.767";
```

Isso seria no lugar do já padrão conhecido:

```csharp
int inteiro = "7899".ToInt();
double decimal = "897.767".ToDouble();
```
---
Mas a principal vantagem é que estamos construindo uma classe para tal conversão, e com isso, fica muito mais organizado manter **regras de conversão** em um objeto de classe, do que simplesmente dentro de um método.

**IMAGINE AS REGRAS COMPLEXAS !!!**