### PR TITLE
Corrige bugs no registro de Workes na infraestrutura ASP.NET

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,10 @@ title: Notas de Lançamento
 Notas de Lançamento
 ===================
 
+## 0.10.1
+
+* Correção de bugs no registro de `Workers` na infraestrutura ASP.NET
+
 ## 0.10.0
 
 ### Novos recursos:

--- a/packages.props
+++ b/packages.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.10.0</VersionPrefix>
+        <VersionPrefix>0.10.1</VersionPrefix>
         <FileVersion>$(VersionPrefix).0</FileVersion>
         <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
         <RootPkgNamespace>E5R.Architecture</RootPkgNamespace>

--- a/src/E5R.Architecture.Infrastructure.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/E5R.Architecture.Infrastructure.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Checker.NotNullArgument(options, nameof(options));
             
-            services.TryAddScoped(typeof(WorkManagerOptions), _ => options);
+            services.TryAddSingleton(typeof(WorkManagerOptions), _ => options);
 
             return services;
         }
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddHostedWorker<TWorker>(this IServiceCollection services)
             where TWorker : IWorker
         {
-            services.TryAddScoped(typeof(TWorker));
+            services.TryAddSingleton(typeof(TWorker));
 
             return services.AddHostedService<WorkManager<TWorker>>();
         }


### PR DESCRIPTION
Os workers, bem como suas opções estavam sendo registrados como `Scoped`, enquanto que um `AddHostedService` do ASP.NET sempre é registrado como `Singleton`. Isso causava falha ao usar mais de um Worker que compartilhavam opções entre si